### PR TITLE
Added -std=gnu99 into CC variables in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -201,13 +201,13 @@ else
 fi
 
 echo -e "${GREEN}$0${OFF}: building the LowFat config builder..."
-(cd config; CC=$CLANG CXX=$CLANGXX make >/dev/null)
+(cd config; CC=$CLANG CFLAGS="-std=gnu99" CXX=$CLANGXX make >/dev/null)
 
 echo -e "${GREEN}$0${OFF}: building the LowFat config..."
 (cd config; ./lowfat-config $CONFIG > lowfat-config.log)
 
 echo -e "${GREEN}$0${OFF}: building the LowFat config check..."
-(cd config; CC=$CLANG CXX=$CLANGXX make lowfat-check-config >/dev/null)
+(cd config; CC=$CLANG CLFAGS="-std=gnu99" CXX=$CLANGXX make lowfat-check-config >/dev/null)
 
 echo -e "${GREEN}$0${OFF}: checking the LowFat config..."
 if config/lowfat-check-config >/dev/null 2>&1
@@ -225,7 +225,7 @@ then
 fi
 
 echo -e "${GREEN}$0${OFF}: building the LowFat pointer info tool..."
-(cd config; CC=$CLANG CXX=$CLANGXX make lowfat-ptr-info >/dev/null)
+(cd config; CC=$CLANG CFLAGS="-std=gnu99" CXX=$CLANGXX make lowfat-ptr-info >/dev/null)
 
 if [ x$HAVE_CLANG_4 = xfalse ]
 then

--- a/config/Makefile
+++ b/config/Makefile
@@ -1,11 +1,11 @@
 lowfat-config: lowfat-config.c
-	$(CC) -o lowfat-config lowfat-config.c -lm -lpthread -O2
+	$(CC) $(CFLAGS) -o lowfat-config lowfat-config.c -lm -lpthread -O2
 
 lowfat-check-config: lowfat-check-config.c
-	$(CC) -o lowfat-check-config lowfat-check-config.c -lm -lpthread -O2
+	$(CC) $(CFLAGS) -o lowfat-check-config lowfat-check-config.c -lm -lpthread -O2
 
 lowfat-ptr-info: lowfat-ptr-info.c
-	$(CC) -o lowfat-ptr-info lowfat-ptr-info.c -lm -lpthread -O2
+	$(CC) $(CFLAGS) -o lowfat-ptr-info lowfat-ptr-info.c -lm -lpthread -O2
 
 clean:
 	rm -f lowfat-config lowfat-check-config lowfat-ptr-info *.o *.i *.s *.ii \


### PR DESCRIPTION
To prevent compilation errors with at least gcc 4.8.4, such as the following:
```
./build.sh: using the default LowFat configuration (sizes.cfg 32)...
./build.sh: warning: clang-4.0 is not installed!
./build.sh: will try the default clang.
./build.sh: checking the CPU...
./build.sh: warning: CPU does not support BMI

./build.sh: warning: CPU does not support BMI2

./build.sh: warning: CPU does not support LZCNT
./build.sh: building the LowFat config builder...
lowfat-config.c: In function ‘error_worker’:
lowfat-config.c:103:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
     for (size_t i = 0; i < sizes_len; i++)
     ^
lowfat-config.c:103:5: note: use option -std=c99 or -std=gnu99 to compile your code
lowfat-config.c:143:9: error: ‘for’ loop initial declarations are only allowed in C99 mode
         for (uintptr_t ptr = region_start; ptr <= region_end; ptr += size)
         ^
lowfat-config.c: In function ‘main’:
lowfat-config.c:380:17: error: redeclaration of ‘i’ with no linkage
     for (size_t i = 0; i < sizes_len; i++)
                 ^
lowfat-config.c:325:12: note: previous declaration of ‘i’ was here
     size_t i;
            ^
lowfat-config.c:380:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
     for (size_t i = 0; i < sizes_len; i++)
     ^
lowfat-config.c:394:9: error: ‘for’ loop initial declarations are only allowed in C99 mode
         for (size_t i = 0; i < sizes_len; i++)
         ^
lowfat-config.c:405:9: error: ‘for’ loop initial declarations are only allowed in C99 mode
         for (size_t i = 0; i < sizes_len; i++)
         ^
lowfat-config.c:423:9: error: ‘for’ loop initial declarations are only allowed in C99 mode
         for (size_t i = 0; i < sizes_len; i++)
         ^
lowfat-config.c:425:21: error: redefinition of ‘i’
         for (size_t i = 0; i < NUM_WORKERS; i++)
                     ^
lowfat-config.c:423:21: note: previous definition of ‘i’ was here
         for (size_t i = 0; i < sizes_len; i++)
                     ^
lowfat-config.c:425:9: error: ‘for’ loop initial declarations are only allowed in C99 mode
         for (size_t i = 0; i < NUM_WORKERS; i++)
         ^
lowfat-config.c:428:21: error: redefinition of ‘i’
         for (size_t i = 0; i < NUM_WORKERS; i++)
                     ^
lowfat-config.c:425:21: note: previous definition of ‘i’ was here
         for (size_t i = 0; i < NUM_WORKERS; i++)
                     ^
lowfat-config.c:428:9: error: ‘for’ loop initial declarations are only allowed in C99 mode
         for (size_t i = 0; i < NUM_WORKERS; i++)
         ^
lowfat-config.c:430:21: error: redefinition of ‘i’
         for (size_t i = 0; i < sizes_len; i++)
                     ^
lowfat-config.c:428:21: note: previous definition of ‘i’ was here
         for (size_t i = 0; i < NUM_WORKERS; i++)
                     ^
lowfat-config.c:430:9: error: ‘for’ loop initial declarations are only allowed in C99 mode
         for (size_t i = 0; i < sizes_len; i++)
         ^
lowfat-config.c: In function ‘stack_select’:
lowfat-config.c:474:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
     for (size_t i = 0; i < sizes_len; i++)
     ^
lowfat-config.c: In function ‘compile’:
lowfat-config.c:542:9: error: ‘for’ loop initial declarations are only allowed in C99 mode
         for (size_t i = 0; i < sizes_len; i++)
         ^
lowfat-config.c:631:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
     for (ssize_t i = sizes_len-1; i >= 0; i--)
     ^
lowfat-config.c:662:17: error: conflicting types for ‘i’
     for (size_t i = 0; i < sizes_len; i++)
                 ^
lowfat-config.c:631:18: note: previous definition of ‘i’ was here
     for (ssize_t i = sizes_len-1; i >= 0; i--)
                  ^
lowfat-config.c:662:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
     for (size_t i = 0; i < sizes_len; i++)
     ^
lowfat-config.c:671:17: error: redefinition of ‘i’
     for (size_t i = 0; i < sizes_len; i++)
                 ^
lowfat-config.c:662:17: note: previous definition of ‘i’ was here
     for (size_t i = 0; i < sizes_len; i++)
                 ^
lowfat-config.c:671:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
     for (size_t i = 0; i < sizes_len; i++)
     ^
lowfat-config.c:681:17: error: redefinition of ‘i’
     for (size_t i = 0; i < sizes_len; i++)
                 ^
lowfat-config.c:671:17: note: previous definition of ‘i’ was here
     for (size_t i = 0; i < sizes_len; i++)
                 ^
lowfat-config.c:681:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
     for (size_t i = 0; i < sizes_len; i++)
     ^
lowfat-config.c:698:17: error: redefinition of ‘i’
     for (size_t i = 0; i < 65; i++)
                 ^
lowfat-config.c:681:17: note: previous definition of ‘i’ was here
     for (size_t i = 0; i < sizes_len; i++)
                 ^
lowfat-config.c:698:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
     for (size_t i = 0; i < 65; i++)
     ^
lowfat-config.c:714:17: error: redefinition of ‘i’
     for (size_t i = 0; i < 65; i++)
                 ^
lowfat-config.c:698:17: note: previous definition of ‘i’ was here
     for (size_t i = 0; i < 65; i++)
                 ^
lowfat-config.c:714:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
     for (size_t i = 0; i < 65; i++)
     ^
lowfat-config.c:735:17: error: redefinition of ‘i’
     for (size_t i = 0; i < 65; i++)
                 ^
lowfat-config.c:714:17: note: previous definition of ‘i’ was here
     for (size_t i = 0; i < 65; i++)
                 ^
lowfat-config.c:735:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
     for (size_t i = 0; i < 65; i++)
     ^
lowfat-config.c:762:18: error: conflicting types for ‘i’
     for (ssize_t i = 64-1; i >= 0; i--)
                  ^
lowfat-config.c:735:17: note: previous definition of ‘i’ was here
     for (size_t i = 0; i < 65; i++)
                 ^
lowfat-config.c:762:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
     for (ssize_t i = 64-1; i >= 0; i--)
     ^
lowfat-config.c:765:9: error: ‘for’ loop initial declarations are only allowed in C99 mode
         for (size_t j = 0; j < sizes_len; j++)
         ^
make: *** [lowfat-config] Error 1
```